### PR TITLE
Fixing test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,12 @@
             <version>RELEASE</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.easytesting</groupId>
+            <artifactId>fest-assert</artifactId>
+            <version>1.4</version>
+            <scope>test</scope>
+        </dependency>
         <!--**********/TESTING**********-->
 
 

--- a/src/test/java/UserTest.java
+++ b/src/test/java/UserTest.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 
 import testpkg.User;
+
+import org.fest.assertions.Assertions;
 import org.hibernate.*;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.ogm.cfg.OgmConfiguration;
@@ -76,23 +78,18 @@ public class UserTest {
 
         Session session = sessionFactory.openSession();
         Transaction tx = session.beginTransaction();
+        User newUser = new User( null, "Threeflower", 9, "Octarine 3" );
+        session.persist( newUser );
+        tx.commit();
+        session.clear();
 
-       // Query q = session.createSQLQuery("select  *  from \"User\"").addEntity(testpkg.User.class);
+        tx = session.beginTransaction();
         Query q = session.createQuery("FROM User");
-//        Query
-
-        @SuppressWarnings("unchecked")
         List listUsers = q.list();
         tx.commit();
         session.close();
+
         assertFalse(listUsers.isEmpty());
-
-//        for (User u: listUsers) {
-//            if(u != null)
-//                System.out.println(u);
-//            else
-//                fail("Didn't get testpkg.User Object types");
-//        }
+        Assertions.assertThat( listUsers ).onProperty( "name" ).contains( newUser.getName() );
     }
-
 }


### PR DESCRIPTION
This changes to the test will make it work.

The reason it wasn't working is that OGM uses the Hibernate Search index to look for the entities.
Once it finds them then it retrieve the from the DB.
Since in your test the index is saved in RAM, it gets deleted every time you re-run them and therfore it cannot find the data in it.

The solution can be:
- re-index the data in the DB using the MassIndexer
- store the index somewhere 
- Look for entities created before closing the session factory

I added a few commit to the project to add a library to test assertions and to insert data and look for them using the same session factory. In theoy, when you work with unit tests you should also delete the data after the test is over, to keep the DB clean.

I hope this help,
Davide
